### PR TITLE
fixed Z_PROBE for handwheel operation

### DIFF
--- a/MACROS/V7_macro.cnc
+++ b/MACROS/V7_macro.cnc
@@ -375,8 +375,10 @@ Sub Z_PROBE ; Probe for Work Z-zero height
 		;--------------------------------------------------
 		#4518 = 0 				; FLAG: Move back to operation starting point (1=YES, 0=NO)
 		IF [#3505 == 0] 			; FLAG whether Tool Length Measurement called from handwheel 1=Handwheel
-			DlgMsg "Measure Work Z 0" 
-		ENDIF	
+			DlgMsg "Measure Work Z 0"
+		ELSE					; measurement was initiated from handwheel, no UI dialog is shown
+			#5398 = 1;			; explicitly set OK button status to avoid unintended aborts
+		ENDIF
 		#3505 = 0				; FLAG whether Tool Length Measurement called from handwheel 1=Handwheel
 		IF [[#5398 == 1] AND [#5397 == 0]]	; OK button pressed and RENDER Mode off !!
 			M5	; Spindle shutdown


### PR DESCRIPTION
Mir ist aufgefallen, dass manchmal der Druck auf die Taste “Probe Z” auf dem Handrad nicht dazu führt, dass der WZL-Sensor angetastet wird. Rufe ich dann die Z-Nullpunktermittlung über die Eding Benutzeroberfläche (user-Menü) auf, funktioniert’s. Es liegt an der Abfrage der Variable #5398 - also dem "Return value for dlgmsg (+1 OK, -1 Cancel)". Wird die Subroutine “user_1” vom Handrad aufgerufen, wird explizit nicht mehr der Dialog zum Bestätigen aufgerufen. Das ist auch gut so, denn so kann man den Vorgang komplett am Handrad ausführen. Allerdings wird dann auch nicht die Variable #5398 gesetzt, sondern bleibt auf dem Wert, den man beim letzten Dialog gewählt hatte.

In meinem Fall ist das häufig “Werkzeug bereits eingelegt. Trotzdem wechseln?” - den ich regelmäßig mit “Cancel” verlasse. Logisch. Die Variable #5398 ist dann auf -1 gesetzt.

Lösungsvorschlag:
In dem Fall, in dem das Dialog-Fenster nicht aufgeschaltet wird, müsste man die Variable #5398 explizit auf 1 setzen, damit bei der folgenden Abfrage auch der richtige Code-Pfad durchlaufen wird.